### PR TITLE
Twig filter > Block > Render blocks defined by at_base as simple as other modules

### DIFF
--- a/lib/Drupal/at_base/Tests/Web/TwigTest.php
+++ b/lib/Drupal/at_base/Tests/Web/TwigTest.php
@@ -36,9 +36,9 @@ class TwigTest extends \DrupalWebTestCase {
    * Test easy block definition.
    */
   public function testEasyBlocks() {
-    $block_1 = \AT::twig_string()->render("{{ 'at_base:atest_base|hi_s'  | drupalBlock(TRUE) }}");
-    $block_2 = \AT::twig_string()->render("{{ 'at_base:atest_base|hi_t'  | drupalBlock(TRUE) }}");
-    $block_3 = \AT::twig_string()->render("{{ 'at_base:atest_base|hi_ts' | drupalBlock(TRUE) }}");
+    $block_1 = \AT::twig_string()->render("{{ 'atest_base:hi_s'  | drupalBlock(TRUE) }}");
+    $block_2 = \AT::twig_string()->render("{{ 'atest_base:hi_t'  | drupalBlock(TRUE) }}");
+    $block_3 = \AT::twig_string()->render("{{ 'atest_base:hi_ts' | drupalBlock(TRUE) }}");
 
     $expected = 'Hello Andy Truong';
     $this->assertEqual($expected, trim($block_1));

--- a/lib/Twig/Filters/Block.php
+++ b/lib/Twig/Filters/Block.php
@@ -57,15 +57,19 @@ class Block {
       throw new \Exception('Invalid module');
     }
 
+    // Case of modules which use at_base to define the blocks
+    if (!function_exists("{$module}_block_info")) {
+      $delta = "{$module}|{$delta}";
+      $module = 'at_base';
+    }
+
     if (!$block = block_load($module, $delta)) {
       throw new \Exception('Block not found');
     }
 
     // Make sure properties are set
-    $block->region = -1;
-    if (!isset($block->title)) {
-      $block->title = '';
-    }
+    $block->region = isset($block->region) ? $block->region : -1;
+    $block->title = isset($block->title) ? $block->title : '';
 
     return $block;
   }


### PR DESCRIPTION
Twig filter > Block > Render blocks defined by at_base as simple as other modules
- Old: {{ 'at_base:atest_base|hi_s'  | drupalBlock() }}
- Improved: {{ 'atest_base:hi_s'  | drupalBlock() }}
