### PR TITLE
Breadcrumb API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # Install Drush
   # ---------------------
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - composer global require drush/drush:6.*
+  - composer global require drush/drush:dev-master
 
   # ---------------------
   # Setup DB
@@ -36,7 +36,7 @@ before_script:
   - export VENDOR=`pwd`
   - cd ..
   - export DRUPAL=`pwd`'/drupal/'
-  
+
   # ---------------------
   # Download the codebase
   # ---------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,5 @@ before_script:
   - drush cc all
 
 script:
-  - drush test-run --dirty 'Drupal\at_base\Tests\Unit\BreadcrumbTest'
-  #- drush test-run --dirty 'AT Unit'
-  #- drush test-run --dirty 'AT Web'
+  - drush test-run --dirty 'AT Unit'
+  - drush test-run --dirty 'AT Web'

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,5 +59,6 @@ before_script:
   - drush cc all
 
 script:
-  - drush test-run --dirty 'AT Unit'
-  - drush test-run --dirty 'AT Web'
+  - drush test-run --dirty 'Drupal\at_base\Tests\Unit\BreadcrumbTest'
+  #- drush test-run --dirty 'AT Unit'
+  #- drush test-run --dirty 'AT Web'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Provide some more API for developer to work with Drupal 7.
 - [Config](https://github.com/andytruong/at_base/wiki/7.x-2.x-config)
 - [Service Container](https://github.com/andytruong/at_base/wiki/7.x-2.x-service-container)
 - [Easy Routing](https://github.com/andytruong/at_base/wiki/7.x-2.x-easy-routing)
+- [Easy Breadcrumb](https://github.com/andytruong/at_base/wiki/7.x-2.x-easy-breadcrumb)
 - [Easy Block](https://github.com/andytruong/at_base/wiki/7.x-2.x-easy-routing)
 - [Useful functions](https://github.com/andytruong/at_base/wiki/7.x-2.x-functions)
 - [Twig template](https://github.com/andytruong/at_base/wiki/7.x-2.x-twig-recipes)

--- a/at_base.hack.inc
+++ b/at_base.hack.inc
@@ -25,6 +25,19 @@ function at_debug() {
 }
 
 /**
+ * Override default callback of $fn.
+ *
+ * @see  at_fn()
+ * @param  string   $fn
+ * @param  callable $callback
+ */
+function at_fn_fake($fn, $callback) {
+  global $conf;
+
+  $conf["atfn:{$fn}"] = $callback;
+}
+
+/**
  * Wrapper for class based forms.
  */
 function at_form_validate($form, &$form_state) {

--- a/at_base.hooks.inc
+++ b/at_base.hooks.inc
@@ -69,6 +69,15 @@ function at_base_admin_paths() {
 ###############################################################
 
 /**
+ * Implements hook_entity_view()
+ */
+function at_base_entity_view($entity, $type, $view_mode, $langcode) {
+  if (!empty($_GET['aa'])) {
+    at_container('breadcrumb_api')->checkEntityConfig($entity, $type, $view_mode, $langcode);
+  }
+}
+
+/**
  * Implements hook_entity_insert()
  */
 function at_base_entity_update($entity, $type) {

--- a/at_base.hooks.inc
+++ b/at_base.hooks.inc
@@ -72,10 +72,8 @@ function at_base_admin_paths() {
  * Implements hook_entity_view()
  */
 function at_base_entity_view($entity, $type, $view_mode, $langcode) {
-  if (!empty($_GET['aa'])) { // @todo Remove debug code
     at_container('breadcrumb_api')->checkEntityConfig($entity, $type, $view_mode, $langcode);
   }
-}
 
 /**
  * Implements hook_entity_insert()

--- a/at_base.hooks.inc
+++ b/at_base.hooks.inc
@@ -72,8 +72,8 @@ function at_base_admin_paths() {
  * Implements hook_entity_view()
  */
 function at_base_entity_view($entity, $type, $view_mode, $langcode) {
-    at_container('breadcrumb_api')->checkEntityConfig($entity, $type, $view_mode, $langcode);
-  }
+  at_container('breadcrumb_api')->checkEntityConfig($entity, $type, $view_mode, $langcode);
+}
 
 /**
  * Implements hook_entity_insert()
@@ -142,7 +142,5 @@ function at_base_page_build(&$page) {
     at_id(new Hook_Page_Build($page, at_container('page.blocks')))->execute();
   }
 
-  if (at_container('container')->offsetExists('breadcrumb')) {
-    at_container('breadcrumb_api')->execute(at_container('breadcrumb'));
-  }
+  at_container('breadcrumb_api')->pageBuild();
 }

--- a/at_base.hooks.inc
+++ b/at_base.hooks.inc
@@ -72,7 +72,7 @@ function at_base_admin_paths() {
  * Implements hook_entity_view()
  */
 function at_base_entity_view($entity, $type, $view_mode, $langcode) {
-  if (!empty($_GET['aa'])) {
+  if (!empty($_GET['aa'])) { // @todo Remove debug code
     at_container('breadcrumb_api')->checkEntityConfig($entity, $type, $view_mode, $langcode);
   }
 }

--- a/at_base.hooks.inc
+++ b/at_base.hooks.inc
@@ -144,17 +144,3 @@ function at_base_page_build(&$page) {
     at_id(new Hook_Page_Build($page, at_container('page.blocks')))->execute();
   }
 }
-
-/**
- * Implements hook_node_insert()
- */
-function at_base_node_insert($node) {
-  module_invoke_all('node_save', $node);
-}
-
-/**
- * Implements hook_node_update()
- */
-function at_base_node_update($node) {
-  module_invoke_all('node_save', $node);
-}

--- a/at_base.hooks.inc
+++ b/at_base.hooks.inc
@@ -143,4 +143,8 @@ function at_base_page_build(&$page) {
   if (at_container('container')->offsetExists('page.blocks')) {
     at_id(new Hook_Page_Build($page, at_container('page.blocks')))->execute();
   }
+
+  if (at_container('container')->offsetExists('breadcrumb')) {
+    at_container('breadcrumb_api')->execute(at_container('breadcrumb'));
+  }
 }

--- a/at_base.missing.inc
+++ b/at_base.missing.inc
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @file at_base.missing.inc
+ *
+ * Provide missing API
+ */
+
+/**
+ * Implements hook_node_insert()
+ */
+function at_base_node_insert($node) {
+  module_invoke_all('node_save', $node);
+}
+
+/**
+ * Implements hook_node_update()
+ */
+function at_base_node_update($node) {
+  module_invoke_all('node_save', $node);
+}
+
+if (!function_exists('entity_bundle')) {
+  function entity_bundle($entity_type, $entity) {
+    $info = entity_get_info($entity_type);
+    if (!empty($info['entity keys']['bundle'])) {
+      $key = $info['entity keys']['bundle'];
+      return isset($entity->$key) ? $entity->$key : NULL;
+    }
+  }
+}

--- a/at_base.module
+++ b/at_base.module
@@ -11,6 +11,7 @@ use \Drupal\at_base\Helper\ModulesFetcher;
 require_once dirname(__FILE__) . '/lib/AT.php';
 require_once dirname(__FILE__) . '/lib/Autoloader.php';
 require_once dirname(__FILE__) . '/at_base.hooks.inc';
+require_once dirname(__FILE__) . '/at_base.missing.inc';
 require_once dirname(__FILE__) . '/at_base.hack.inc';
 
 /**

--- a/at_base.module
+++ b/at_base.module
@@ -76,6 +76,23 @@ function at_container($id) {
 }
 
 /**
+ * Make function easier to be replaced by an other one.
+ *
+ * For example:
+ *
+ *  // Override entity_bundle function
+ *  $GLOBALS['conf']['atfn:entity_bundle'] = function($type, $entity) { return $entity->type; };
+ *
+ *  Call replacable entity_bundle function:
+ *    at_fn('entity_bundle', 'node', $node);
+ */
+function at_fn() {
+  $args = func_get_args();
+  $fn   = array_shift($args);
+  return call_user_func_array(variable_get("atfn:{$fn}", $fn), $args);
+}
+
+/**
  * Care about site caching.
  *
  * @param  array|string $options

--- a/at_base.module
+++ b/at_base.module
@@ -178,7 +178,7 @@ function at_library($name, $version = 'default', $include_drupal_root = TRUE) {
     }
 
     if (FALSE !== @fileowner($return)) {
-      return $include_drupal_root ? $return : substr($return, strlen(DRUPAL_ROOT) + 1);
+      return $include_drupal_root ? rtrim($return, '/') : substr($return, strlen(DRUPAL_ROOT) + 1);
     }
   }
 

--- a/at_base.module
+++ b/at_base.module
@@ -85,6 +85,8 @@ function at_container($id) {
  *
  *  Call replacable entity_bundle function:
  *    at_fn('entity_bundle', 'node', $node);
+ *
+ *  @see  at_fn_fake()
  */
 function at_fn() {
   $args = func_get_args();

--- a/config/services.yml
+++ b/config/services.yml
@@ -15,3 +15,6 @@ services:
     class: 'Symfony\Component\ExpressionLanguage\ExpressionLanguage'
     factory_class: 'AT'
     factory_method: getExpressionLanguage
+
+  breadcrumb_api:
+    class: 'Drupal\at_base\Helper\BreadcrumbAPI'

--- a/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
+++ b/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\at_base\Tests\Unit;
+
+use Drupal\at_base\Helper\Test\UnitTestCase;
+use Drupal\at_base\Helper\Test\Cache;
+
+class BreadcrumbTest extends UnitTestCase {
+  public function getInfo() {
+    return array('name' => 'AT Unit: Breadcrumb API') + parent::getInfo();
+  }
+
+  public function testNodeStatic() {
+    $api = at_container('breadcrumb_api');
+
+    $node = new \stdClass();
+    $node->type = 'page';
+
+    $config = array();
+    $config['breadcrumbs']['entity']['node']['page']['full']['breadcrumbs'] = array(
+      array('Home', 'home'),
+    );
+
+    // Direct set without hook_entity_view() implementation
+    $api->checkEntityConfig($node, 'node', 'full', 'und');
+
+    $page = array();
+    at_base_page_build($page);
+
+    $bc = drupal_set_breadcrumb();
+    $this->assertEqual('Home', $bc[0][0]);
+    $this->assertEqual('/home', $bc[0][1]);
+  }
+
+  public function testPath() {
+  }
+}

--- a/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
+++ b/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
@@ -6,30 +6,43 @@ use Drupal\at_base\Helper\Test\UnitTestCase;
 use Drupal\at_base\Helper\Test\Cache;
 
 class BreadcrumbTest extends UnitTestCase {
+  private $api;
+
   public function getInfo() {
     return array('name' => 'AT Unit: Breadcrumb API') + parent::getInfo();
   }
 
+  public function setUp() {
+    parent::setUp();
+    $this->api = at_container('breadcrumb_api');
+  }
+
+  protected function setUpModules() {
+    parent::setUpModules();
+
+    at_container('wrapper.cache')
+      ->set('atmodules:at_base:breadcrumb', array('atest_base'), 'cache_bootstrap');
+  }
+
   public function testNodeStatic() {
-    $api = at_container('breadcrumb_api');
+    global $conf;
 
-    $node = new \stdClass();
-    $node->type = 'page';
+    // Override entity_bundle(), token_replace(), l()
+    $conf['atfn:entity_bundle'] = function($type, $entity) { return $entity->type; };
+    $conf['atfn:token_replace'] = function($input) { return $input; };
+    $conf['atfn:l'] = function($text, $url) { return '<a href="/'. $url .'">'. $text .'</a>'; };
 
-    $config = array();
-    $config['breadcrumbs']['entity']['node']['page']['full']['breadcrumbs'] = array(
-      array('Home', 'home'),
-    );
+    $node = (object) array('type' => 'page', 'nid' => 1, 'title' => 'Test page', 'status' => 1);
 
     // Direct set without hook_entity_view() implementation
-    $api->checkEntityConfig($node, 'node', 'full', 'und');
+    if ($config = $this->api->fetchEntityConfig($node, 'node', 'full', 'und')) {
+      $this->api->set($config);
+    }
 
-    $page = array();
-    at_base_page_build($page);
+    $this->api->pageBuild();
 
     $bc = drupal_set_breadcrumb();
-    $this->assertEqual('Home', $bc[0][0]);
-    $this->assertEqual('/home', $bc[0][1]);
+    $this->assertEqual(at_fn('l', 'Home', 'home'), $bc[0]);
   }
 
   public function testPath() {

--- a/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
+++ b/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
@@ -20,18 +20,18 @@ class BreadcrumbTest extends UnitTestCase {
   protected function setUpModules() {
     parent::setUpModules();
 
-    at_container('wrapper.cache')
-      ->set('atmodules:at_base:breadcrumb', array('atest_base'), 'cache_bootstrap');
+    // Fake at_modules('at_base', 'breadcrumb');
+    at_container('wrapper.cache')->set('atmodules:at_base:breadcrumb', array('atest_base'), 'cache_bootstrap');
+
+    // Fake entity_bundle(), token_replace(), l() functions
+    at_fn_fake('entity_bundle', function($type, $entity) { return $entity->type; });
+    at_fn_fake('token_replace', function($input) { return $input; });
+    at_fn_fake('drupal_get_path_alias', function($input) { return $input; });
+    at_fn_fake('l', function($text, $url) { return '<a href="/'. $url .'">'. $text .'</a>'; });
+    at_fn_fake('request_path', function() { return 'test/path/breadcrumb'; });
   }
 
   public function testNodeStatic() {
-    global $conf;
-
-    // Override entity_bundle(), token_replace(), l()
-    $conf['atfn:entity_bundle'] = function($type, $entity) { return $entity->type; };
-    $conf['atfn:token_replace'] = function($input) { return $input; };
-    $conf['atfn:l'] = function($text, $url) { return '<a href="/'. $url .'">'. $text .'</a>'; };
-
     $node = (object) array('type' => 'page', 'nid' => 1, 'title' => 'Test page', 'status' => 1);
 
     // Direct set without hook_entity_view() implementation

--- a/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
+++ b/lib/Drupal/at_base/Tests/Unit/BreadcrumbTest.php
@@ -28,7 +28,6 @@ class BreadcrumbTest extends UnitTestCase {
     at_fn_fake('token_replace', function($input) { return $input; });
     at_fn_fake('drupal_get_path_alias', function($input) { return $input; });
     at_fn_fake('l', function($text, $url) { return '<a href="/'. $url .'">'. $text .'</a>'; });
-    at_fn_fake('request_path', function() { return 'test/path/breadcrumb'; });
   }
 
   public function testNodeStatic() {
@@ -46,5 +45,29 @@ class BreadcrumbTest extends UnitTestCase {
   }
 
   public function testPath() {
+    // Current path is /test/path/foo
+    // Active breadcrumb should be 'test/path/foo'
+    at_fn_fake('request_path', function() { return 'test/path/foo'; });
+    $this->api->pageBuild();
+    $bc = drupal_set_breadcrumb();
+    $this->assertEqual(at_fn('l', 'Foo 1', 'foo/1'), $bc[0]);
+    $this->assertEqual(at_fn('l', 'Foo 2', 'foo/2'), $bc[1]);
+
+    // Current path is /test/path/wildcard
+    // Active breadcrumb should be 'test/path/*'
+    at_fn_fake('request_path', function() { return 'test/path/wildcard'; });
+    $this->api->pageBuild();
+    $bc = drupal_set_breadcrumb();
+    $this->assertEqual(at_fn('l', 'Wildcard 1', 'wildcard/1'), $bc[0]);
+    $this->assertEqual(at_fn('l', 'Wildcard 2', 'wildcard/2'), $bc[1]);
+
+    // Current path is /test/path/bar
+    // Active breadcrumb should not be 'test/path/bar', per weight of it is
+    // lower priority then 'test/path/*'
+    at_fn_fake('request_path', function() { return 'test/path/bar'; });
+    $this->api->pageBuild();
+    $bc = drupal_set_breadcrumb();
+    $this->assertEqual(at_fn('l', 'Wildcard 1', 'wildcard/1'), $bc[0]);
+    $this->assertEqual(at_fn('l', 'Wildcard 2', 'wildcard/2'), $bc[1]);
   }
 }

--- a/lib/Drupal/at_base/Tests/Unit/CommonTest.php
+++ b/lib/Drupal/at_base/Tests/Unit/CommonTest.php
@@ -67,4 +67,15 @@ class CommonTest extends UnitTestCase {
     $actual = $engine->evaluate("constant('MENU_CONTEXT_PAGE') | constant('MENU_CONTEXT_INLINE')");
     $this->assertEqual($expected, $actual);
   }
+
+  /**
+   * Test at_fn()
+   */
+  public function testAtFn() {
+    // Fake the function
+    $GLOBALS['conf']['atfn:entity_bundle'] = function($type, $entity) { return $entity->type; };
+
+    // Make sure the fake function is executed
+    $this->assertEqual('page', at_fn('entity_bundle', 'node', (object)array('type' => 'page')));
+  }
 }

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -43,8 +43,6 @@ class BreadcrumbAPI {
     $cache_callback = array($this, 'fetchEntityConfig');
     $cache_arguments = func_get_args();
 
-    $cache_options['reset'] = TRUE;
-
     if ($config = at_cache($cache_options, $cache_callback, $cache_arguments)) {
       $config['context'] = array('type' => 'entity', 'arguments' => $cache_arguments);
       $this->set($config);

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -131,12 +131,12 @@ class BreadcrumbAPI {
       switch ($config['context']['type']) {
         case 'entity':
         case 'path':
-          return $this->buildBreadcrumbs($bc, $config['tokens'], $config['context']['arguments']);
+          return $this->buildBreadcrumbs($bc, $config['context']['arguments']);
       }
     }
   }
 
-  private function buildBreadcrumbs($bc = array(), $tokens = array(), $args = array()) {
+  private function buildBreadcrumbs($bc = array(), $args = array()) {
     global $user;
 
     $token_data = array('user' => $user);

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -121,6 +121,10 @@ class BreadcrumbAPI {
     if ($config = $this->get()) {
       $bc = !empty($config['breadcrumbs']) ? $config['breadcrumbs'] : array();
 
+      if (empty($bc)) {
+        $bc = at_container('helper.content_render')->render($config);
+      }
+
       switch ($config['context']['type']) {
         case 'entity':
         case 'path':

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -91,6 +91,31 @@ class BreadcrumbAPI {
       $bc = $config['breadcrumbs'];
     }
 
-    dsm($config);
+    switch ($config['context']['type']) {
+      case 'entity':
+        return $this->buildEntityBreadcrumbs($bc, $config['tokens'], $config['context']['arguments']);
+    }
+  }
+
+  private function buildEntityBreadcrumbs($bc = array(), $tokens = array(), $args = array()) {
+    global $user;
+
+    $token_data = array('user' => $user);
+    switch ($args[1]) {
+      case 'node':
+      case 'user':
+        $token_data[$args[1]] = $args[0];
+        break;
+    }
+
+    foreach ($bc as &$item) {
+      foreach ($item as &$item_e) {
+        $item_e = token_replace($item_e, $token_data);
+      }
+
+      $item = count($item) == 2 ? l($item[0], $item[1]) : reset($item);
+    }
+
+    drupal_set_breadcrumb($bc);
   }
 }

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -46,7 +46,7 @@ class BreadcrumbAPI {
     $cache_options['reset'] = TRUE;
 
     if ($config = at_cache($cache_options, $cache_callback, $cache_arguments)) {
-      $config['context'] = $cache_arguments;
+      $config['context'] = array('type' => 'entity', 'arguments' => $cache_arguments);
       $this->set($config);
     }
   }
@@ -79,5 +79,18 @@ class BreadcrumbAPI {
     if (at_container('container')->offsetExists('breadcrumb')) {
       return at_container('breadcrumb');
     }
+  }
+
+  /**
+   * Apply breadcrumb configuration to page.
+   */
+  public function execute($config) {
+    $bc = array();
+
+    if (!empty($config['breadcrumbs'])) {
+      $bc = $config['breadcrumbs'];
+    }
+
+    dsm($config);
   }
 }

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -1,0 +1,76 @@
+<?php
+namespace Drupal\at_base\Helper;
+
+/**
+ * Callback for breadcrumb_api service.
+ */
+class BreadcrumbAPI {
+  /**
+   * Load breadcrumb configuration for a specific entity/view module. If
+   *   configuraiton is available, set it to service container.
+   *
+   * Example configuration
+   *
+   * file: your_module/config/breadcrumb.yml
+   *
+   * entity:
+   *   node:                   # <-- entity type
+   *     page:                 # <-- bundle
+   *       full:               # <-- view mode
+   *         breadcrumbs:      # <-- static breadcrumb
+   *           - ['Home', '<front>']
+   *           - ['About', 'about-us']
+   *     article:              # <-- bundle
+   *       full:               # <-- view mode
+   *         controller:       # <-- dynamic breadcrumbs, rendered by a controller.
+   *           - class_name
+   *           - method_name
+   *           - [argument_1, argument_2, argument_3]
+   *     gallery:              # <-- bundle
+   *       full:               # <-- view mode
+   *         function:  my_fn  # <-- dynamic breadcrumbs, rendered by a controller.
+   *         arguments: [argument_1, argument_2, argument_3]
+   *
+   * @see at_base_entity_view()
+   * @param  \stdClass $entity
+   * @param  string $type
+   * @param  string $view_mode
+   * @param  string $langcode
+   * @return null
+   */
+  public function checkEntityConfig($entity, $type, $view_mode, $langcode) {
+    $cache_options = array('id' => "atbc:{$type}:{$view_mode}");
+    $cache_callback = array($this, 'fetchEntityConfig');
+    $cache_arguments = array($type, $view_mode);
+    if ($config = at_cache($cache_options, $cache_callback, $cache_arguments)) {
+      $this->set($config);
+    }
+  }
+
+  public function fetchEntityConfig($type, $view_mode) {
+    dsm(array($type, $view_mode));
+    foreach (at_modules('at_base', 'breadcrumb') as $module) {
+      dsm($module);
+    }
+  }
+
+  /**
+   * Set a breacrumb configuration to service container.
+   *
+   * @param array $config
+   */
+  public function set(array $config) {
+    at_container('container')->offsetSet('breadcrumb', $config);
+  }
+
+  /**
+   * Get breadcrumb configuration from service container.
+   *
+   * @return array
+   */
+  public function get() {
+    if (at_container('container')->offsetExists('breadcrumb')) {
+      return at_container('breadcrumb');
+    }
+  }
+}

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -39,12 +39,11 @@ class BreadcrumbAPI {
    * @return null
    */
   public function checkEntityConfig($entity, $type, $view_mode, $langcode) {
-    $cache_options = array('id' => "atbc:{$type}:{$view_mode}");
+    $cache_options = array('id' => "atbc:{$type}:". at_fn('entity_bundle', $type, $entity) .":{$view_mode}");
     $cache_callback = array($this, 'fetchEntityConfig');
     $cache_arguments = func_get_args();
 
     if ($config = at_cache($cache_options, $cache_callback, $cache_arguments)) {
-      $config['context'] = array('type' => 'entity', 'arguments' => $cache_arguments);
       $this->set($config);
     }
   }
@@ -52,9 +51,13 @@ class BreadcrumbAPI {
   public function fetchEntityConfig($entity, $type, $view_mode, $langcode) {
     foreach (at_modules('at_base', 'breadcrumb') as $module) {
       $config = at_config($module, 'breadcrumb')->get('breadcrumb');
-      $bundle = entity_bundle($type, $entity);
-      if (isset($config[$type][$bundle][$view_mode])) {
-        return $config[$type][$bundle][$view_mode];
+
+      $bundle = at_fn('entity_bundle', $type, $entity);
+
+      if (isset($config['entity'][$type][$bundle][$view_mode])) {
+        $return = $config['entity'][$type][$bundle][$view_mode];
+        $return['context'] = array('type' => 'entity', 'arguments' => func_get_args());
+        return $return;
       }
     }
   }
@@ -148,10 +151,10 @@ class BreadcrumbAPI {
 
     foreach ($bc as &$item) {
       foreach ($item as &$item_e) {
-        $item_e = token_replace($item_e, $token_data);
+        $item_e = at_fn('token_replace', $item_e, $token_data);
       }
 
-      $item = count($item) == 2 ? l($item[0], $item[1]) : reset($item);
+      $item = count($item) == 2 ? at_fn('l', $item[0], $item[1]) : reset($item);
     }
 
     drupal_set_breadcrumb($bc);

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -25,7 +25,7 @@ class BreadcrumbAPI {
    *         controller:       # <-- dynamic breadcrumbs, rendered by a controller.
    *           - class_name
    *           - method_name
-   *           - [%entity, %entity_type, %bundle, %view_mode, %langcode]
+   *           - ['%entity', '%entity_type', '%bundle', '%view_mode', '%langcode']
    *     gallery:              # <-- bundle
    *       full:               # <-- view mode
    *         function:  my_fn  # <-- dynamic breadcrumbs, rendered by a controller.
@@ -46,19 +46,17 @@ class BreadcrumbAPI {
     $cache_options['reset'] = TRUE;
 
     if ($config = at_cache($cache_options, $cache_callback, $cache_arguments)) {
-      dsm($config);
+      $config['context'] = $cache_arguments;
       $this->set($config);
     }
   }
 
   public function fetchEntityConfig($entity, $type, $view_mode, $langcode) {
-    if ($type === 'node' && $entity->type === 'resource') { // @todo Remove debug code
-      foreach (at_modules('at_base', 'breadcrumb') as $module) {
-        $config = at_config($module, 'breadcrumb')->get('breadcrumb');
-        $bundle = entity_bundle($type, $entity);
-        if (isset($config[$type][$bundle][$view_mode])) {
-          return $config[$type][$bundle][$view_mode];
-        }
+    foreach (at_modules('at_base', 'breadcrumb') as $module) {
+      $config = at_config($module, 'breadcrumb')->get('breadcrumb');
+      $bundle = entity_bundle($type, $entity);
+      if (isset($config[$type][$bundle][$view_mode])) {
+        return $config[$type][$bundle][$view_mode];
       }
     }
   }

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -75,7 +75,7 @@ class BreadcrumbAPI {
     });
 
     // Convert the Drupal path to lowercase
-    $current_path = drupal_strtolower(drupal_get_path_alias($_GET['q']));
+    $current_path = drupal_strtolower(at_fn('drupal_get_path_alias', at_fn('request_path')));
 
     foreach ($path_config as $path => $config) {
       if (drupal_match_path($current_path, $path)) {

--- a/lib/Helper/BreadcrumbAPI.php
+++ b/lib/Helper/BreadcrumbAPI.php
@@ -65,7 +65,16 @@ class BreadcrumbAPI {
    * @param array $config
    */
   public function set(array $config) {
+    if ($_config = $this->get()) {
+      $old_weight = isset($_config['weight']) ? $_config['weight'] : 0;
+      $new_weight = isset($config['weight'])  ? $config['weight']  : 0;
+      if ($new_weight <= $old_weight) {
     at_container('container')->offsetSet('breadcrumb', $config);
+  }
+    }
+    else {
+      at_container('container')->offsetSet('breadcrumb', $config);
+    }
   }
 
   /**

--- a/lib/Helper/Content_Render/Process.php
+++ b/lib/Helper/Content_Render/Process.php
@@ -39,6 +39,11 @@ class Process {
     if (isset($this->data['controller'])) {
       @list($class, $method, $args) = $this->data['controller'];
       $obj = new $class();
+
+      if (empty($args) && !empty($this->data['arguments'])) {
+        $args = $this->data['arguments'];
+      }
+
       return call_user_func_array(
         array($obj, $method),
         $this->getControllerArguments($args, $obj)

--- a/lib/Helper/Test/UnitTestCase.php
+++ b/lib/Helper/Test/UnitTestCase.php
@@ -36,6 +36,12 @@ abstract class UnitTestCase extends \DrupalUnitTestCase {
     spl_autoload_unregister('drupal_autoload_interface');
     at_id(new Autoloader('Drupal'))->register(FALSE, TRUE);
 
+    $this->setUpModules();
+
+    parent::setUp('at_base', 'atest_base');
+  }
+
+  protected function setUpModules() {
     // at_modules() > system_list() > need db, fake it!
     // 'id' => "ATConfig:{$module}:{$id}:{$key}:" . ($include_at_base ? 1 : 0),
     $cids_1 = array('atmodules:at_base:', 'atmodules:at_base:services', 'atmodules:at_base:twig_functions');
@@ -49,7 +55,5 @@ abstract class UnitTestCase extends \DrupalUnitTestCase {
     foreach ($cids_2 as $cid) {
       at_container('wrapper.cache')->set($cid, $data_2, 'cache_bootstrap');
     }
-
-    parent::setUp('at_base', 'atest_base');
   }
 }

--- a/tests/atest_base/config/breadcrumb.yml
+++ b/tests/atest_base/config/breadcrumb.yml
@@ -6,3 +6,17 @@ breadcrumb:
           breadcrumbs:
             - ['Home', 'home']
 
+  paths:
+    'test/path/*':
+      breadcrumbs:
+        - ['Wildcard 1', 'wildcard/1']
+        - ['Wildcard 2', 'wildcard/2']
+    'test/path/foo':
+      breadcrumbs:
+        - ['Foo 1', 'foo/1']
+        - ['Foo 2', 'foo/2']
+    'test/path/bar':
+      weight: 100
+      breadcrumbs:
+        - ['Foo 1', 'foo/1']
+        - ['Foo 2', 'foo/2']

--- a/tests/atest_base/config/breadcrumb.yml
+++ b/tests/atest_base/config/breadcrumb.yml
@@ -1,0 +1,8 @@
+breadcrumb:
+  entity:
+    node:
+      page:
+        full:
+          breadcrumbs:
+            - ['Home', 'home']
+


### PR DESCRIPTION
### Tasks
- [x] Entity breadcrumb
- [x] Path breadcrumb
- [x] Static breadcrumb
- [x] Dynamic breadcrumb with controller
- [x] [Documentation](/andytruong/at_base/wiki/7.x-2.x-easy-breadcrumb)
- [ ] Documentation for at_fn()
- [ ] Test case
### Example configuration

``` yaml
# ---
# file: your_module/config/breadcrumb.yml
# ---
breadcrumbs
  paths:
    'contact-*':
      weight: -100
      breadcrumbs:
        - ['[site:name]', '[site:url]']
        - ['Current page ->[current-page:title]', '[current-page:url]']
        - ['Demo config of @crom_andy']
  entity:
    node:                   # <-- entity type
      page:                 # <-- bundle
        full:               # <-- view mode
          breadcrumbs:      # <-- static breadcrumb
            - ['[site:name]', '[site:url]'] # <-- support tokens
            - ['About', 'about-us']
      article:              # <-- bundle
        full:               # <-- view mode
          controller:       # <-- dynamic breadcrumbs, rendered by a controller.
            - class_name
            - method_name
            - ['%entity', '%entity_type', '%bundle', '%view_mode', '%langcode']
      gallery:              # <-- bundle
        full:               # <-- view mode
          function:  my_fn  # <-- dynamic breadcrumbs, rendered by a controller.
          arguments: [argument_1, argument_2, argument_3]
```
