### PR TITLE
Attach blocks: The faster way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,5 @@ before_script:
   - drush cc all
 
 script:
-  # - drush test-run --dirty 'AT Unit'
-  # - drush test-run --dirty 'AT Web'
-  - drush test-run --dirty 'Drupal\at_base\Tests\Web\RouteTest' --methods='testRouteBlock'
+  - drush test-run --dirty 'AT Unit'
+  - drush test-run --dirty 'AT Web'

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,5 +59,6 @@ before_script:
   - drush cc all
 
 script:
-  - drush test-run --dirty 'AT Unit'
-  - drush test-run --dirty 'AT Web'
+  # - drush test-run --dirty 'AT Unit'
+  # - drush test-run --dirty 'AT Web'
+  - drush test-run --dirty 'Drupal\at_base\Tests\Web\RouteTest' --methods='testRouteBlock'

--- a/lib/Drupal/at_base/Tests/Web/RouteTest.php
+++ b/lib/Drupal/at_base/Tests/Web/RouteTest.php
@@ -77,13 +77,17 @@ class RouteTest extends \DrupalWebTestCase {
   }
 
   public function testRouteBlock() {
-    at_container('container')
-      ->offsetSet('page.blocks', array(
-        'help' => array(
-          'system:powered-by',
-          array('at_base:atest_base|hi_s', array('title' => 'Hello block!', 'weight' => -100)),
-        )
-      ));
+    $blocks['help'] = array();
+    $blocks['help'][] = 'system:powered-by';
+    $blocks['help'][] = array('at_base:atest_base|hi_s', array('title' => 'Hello block!', 'weight' => -100));
+    $blocks['help'][] = array(
+      'delta'   => 'fancy-block',
+      'subject' => 'Fancy block',
+      'content' => 'Hey Andy!',
+      'weight'  => 1000,
+    );
+
+    at_container('container')->offsetSet('page.blocks', $blocks);
 
     // Render the page array
     $page = array();
@@ -93,5 +97,7 @@ class RouteTest extends \DrupalWebTestCase {
     // Found two blocks
     $this->assertTrue(FALSE !== strpos($output, 'Powered by'));
     $this->assertTrue(FALSE !== strpos($output, 'Hello block!'));
+    $this->assertTrue(FALSE !== strpos($output, 'Fancy block'));
+    $this->assertTrue(FALSE !== strpos($output, 'Hey Andy!'));
   }
 }

--- a/lib/Drupal/at_base/Tests/Web/RouteTest.php
+++ b/lib/Drupal/at_base/Tests/Web/RouteTest.php
@@ -99,5 +99,6 @@ class RouteTest extends \DrupalWebTestCase {
     $this->assertTrue(FALSE !== strpos($output, 'Hello block!'));
     $this->assertTrue(FALSE !== strpos($output, 'Fancy block'));
     $this->assertTrue(FALSE !== strpos($output, 'Hey Andy!'));
+    drush_print_r($output); exit;
   }
 }

--- a/lib/Drupal/at_base/Tests/Web/RouteTest.php
+++ b/lib/Drupal/at_base/Tests/Web/RouteTest.php
@@ -83,7 +83,7 @@ class RouteTest extends \DrupalWebTestCase {
     $blocks['help'][] = array(
       'delta'   => 'fancy-block',
       'subject' => 'Fancy block',
-      'content' => 'Hey Andy!',
+      'content' => array('content' => 'Hey Andy!'),
       'weight'  => 1000,
     );
 
@@ -99,6 +99,6 @@ class RouteTest extends \DrupalWebTestCase {
     $this->assertTrue(FALSE !== strpos($output, 'Hello block!'));
     $this->assertTrue(FALSE !== strpos($output, 'Fancy block'));
     $this->assertTrue(FALSE !== strpos($output, 'Hey Andy!'));
-    drush_print_r($output); exit;
+    drush_print_r($output);
   }
 }

--- a/lib/Hook/Page_Build.php
+++ b/lib/Hook/Page_Build.php
@@ -91,7 +91,12 @@ class Page_Build {
       $key = isset($config['delta']) ? $config['delta'] : md5(serialize($config)),
       $config
     );
-    return (object)array('module' => 'at_base', 'delta' => "dyn_{$key}", 'region' => '');
+    return (object)array(
+      'module' => 'at_base',
+      'delta' => "dyn_{$key}",
+      'region' => '',
+      'title' => '',
+    );
   }
 
   /**

--- a/lib/Hook/Page_Build.php
+++ b/lib/Hook/Page_Build.php
@@ -53,8 +53,8 @@ class Page_Build {
   }
 
   /**
-   * @param  [type] $config [description]
-   * @return [type]         [description]
+   * @param  array $config
+   * @return stdClass
    */
   private function loadBlock($config) {
     if ($this->detectTraditionBlock($config)) {
@@ -91,7 +91,7 @@ class Page_Build {
       $key = isset($config['delta']) ? $config['delta'] : md5(serialize($config)),
       $config
     );
-    return (object)array('module' => 'at_base', 'delta' => "dyn_{$key}");
+    return (object)array('module' => 'at_base', 'delta' => "dyn_{$key}", 'region' => '');
   }
 
   /**
@@ -100,8 +100,8 @@ class Page_Build {
    *  - system:powered-by
    *  - ['user:online', {title: "Online users", weight: -100}]
    *
-   * @param  [type] $config [description]
-   * @return [type]         [description]
+   * @param  array $config
+   * @return \stdClass
    */
   private function loadTraditionBlock($config) {
     list($module, $delta) = explode(':', is_string($config) ? $config : $config[0]);

--- a/lib/Hook/Page_Build.php
+++ b/lib/Hook/Page_Build.php
@@ -7,7 +7,18 @@ namespace Drupal\at_base\Hook;
  * Parse block configuration, build attached-blocks to page structure.
  */
 class Page_Build {
+  /**
+   * Structure of page.
+   *
+   * @var array
+   */
   private $page;
+
+  /**
+   * Configuration of blocks for context page.
+   *
+   * @var array
+   */
   private $blocks;
 
   public function __construct(&$page, $blocks) {
@@ -34,7 +45,7 @@ class Page_Build {
 
   private function loadBlock($config) {
     list($module, $delta) = explode(':', is_string($config) ? $config : $config[0]);
-    
+
     // Case of modules which use at_base to define the blocks
     if (!function_exists("{$module}_block_info")) {
       $delta = "{$module}|{$delta}";

--- a/lib/Hook/Page_Build.php
+++ b/lib/Hook/Page_Build.php
@@ -35,8 +35,8 @@ class Page_Build {
   }
 
   private function renderRegion($region, $blocks) {
-    foreach ($blocks as $slug => &$block) {
-      $block = $this->loadBlock($slug, $block);
+    foreach ($blocks as &$block) {
+      $block = $this->loadBlock($block);
     }
 
     $output = _block_render_blocks($blocks);
@@ -56,13 +56,13 @@ class Page_Build {
    * @param  [type] $config [description]
    * @return [type]         [description]
    */
-  private function loadBlock($slug, $config) {
+  private function loadBlock($config) {
     if ($this->detectTraditionBlock($config)) {
       if ($block = $this->loadTraditionBlock($config)) {
         return $block;
       }
     }
-    elseif ($block = $this->loadFancyBlock($slug, $config)) {
+    elseif ($block = $this->loadFancyBlock($config)) {
       return $block;
     }
   }
@@ -86,7 +86,7 @@ class Page_Build {
    * @param  [type] $config [description]
    * @return [type]         [description]
    */
-  private function loadFancyBlock($slug, $config) {
+  private function loadFancyBlock($config) {
     BlockView::setDynamicData(
       $key = isset($config['delta']) ? $config['delta'] : md5(serialize($config)),
       $config

--- a/lib/Hook/Page_Build.php
+++ b/lib/Hook/Page_Build.php
@@ -57,9 +57,7 @@ class Page_Build {
    * @return [type]         [description]
    */
   private function loadBlock($slug, $config) {
-    $is_tradition = is_string($config) || is_numeric(reset(array_keys($config)));
-
-    if ($is_tradition) {
+    if ($this->detectTraditionBlock($config)) {
       if ($block = $this->loadTraditionBlock($config)) {
         return $block;
       }
@@ -67,6 +65,16 @@ class Page_Build {
     elseif ($block = $this->loadFancyBlock($slug, $config)) {
       return $block;
     }
+  }
+
+  private function detectTraditionBlock($config) {
+    if (is_string($config)) {
+      return TRUE;
+    }
+
+    $keys = array_keys($config);
+    $first_key = reset($keys);
+    return is_numeric($first_key);
   }
 
   /**

--- a/tests/atest_route/config/routes.blocks.yml
+++ b/tests/atest_route/config/routes.blocks.yml
@@ -12,5 +12,5 @@ routes:
           - ['user:online', {title: "Online users", weight: -100}]
           - delta: fancy-block
             subject: 'Fancy block'
-            content: 'Hey Andy!'
+            content: { content: 'Hey Andy!' }
             weight: 1000

--- a/tests/atest_route/config/routes.blocks.yml
+++ b/tests/atest_route/config/routes.blocks.yml
@@ -11,6 +11,6 @@ routes:
           - 'system:powered-by'
           - ['user:online', {title: "Online users", weight: -100}]
           - delta: fancy-block
-            subject: 'Fake block'
+            subject: 'Fancy block'
             content: 'Hey Andy!'
             weight: 1000

--- a/tests/atest_route/config/routes.blocks.yml
+++ b/tests/atest_route/config/routes.blocks.yml
@@ -1,9 +1,16 @@
 routes:
   atest_route/blocks:
+    title: Hello Blocks
     access arguments: ['access content']
-    template_string: 'Hello!'
+    content: >
+      <h1>Main content here!</h1>
+      Hello!
     blocks:
       seven:
         help:
           - 'system:powered-by'
           - ['user:online', {title: "Online users", weight: -100}]
+          - delta: atest-route-fake-block
+            subject: 'Fake block'
+            content: 'Hey Andy!'
+            weight: 1000

--- a/tests/atest_route/config/routes.blocks.yml
+++ b/tests/atest_route/config/routes.blocks.yml
@@ -10,7 +10,7 @@ routes:
         help:
           - 'system:powered-by'
           - ['user:online', {title: "Online users", weight: -100}]
-          - delta: atest-route-fake-block
+          - delta: fancy-block
             subject: 'Fake block'
             content: 'Hey Andy!'
             weight: 1000


### PR DESCRIPTION
The API should allow developer to attach other type of content, not just block, which is too slow for dev time.

``` yml
routes:
  atest_route/blocks:
    title: Hello Blocks
    access arguments: ['access content']
    content: >
      <h1>Main content here!</h1>
      Hello!
    blocks:
      seven:
        help:
          - 'system:powered-by'
          - ['user:online', {title: "Online users", weight: -100}]
          - delta: fancy-block
            subject: 'Fancy block'
            content: { content: 'Hey Andy!' }
            weight: 1000
```
