### PR TITLE
Remove extra space string from render

### DIFF
--- a/lib/Drupal/at_base/Tests/Unit/ServiceContentRenderTest.php
+++ b/lib/Drupal/at_base/Tests/Unit/ServiceContentRenderTest.php
@@ -37,6 +37,12 @@ class ServiceContentRenderTest extends UnitTestCase {
     $output = $this->render->render($data);
     $this->assertEqual('Hello Andy Truong', $output);
   }
+  public function testTemplateStringEmptyReturn() {
+    $data = array();
+    $data['template_string'] = '{% if false %}Empty return{% endif %}';
+    $output = $this->render->render($data);
+    $this->assertEqual('', $output);
+  }
 
   public function testTemplate() {
     $data = array();

--- a/lib/Helper/Content_Render.php
+++ b/lib/Helper/Content_Render.php
@@ -63,7 +63,7 @@ class Content_Render {
 
   public function render($data = NULL) {
     if (!is_null($data)) {
-      $this->setdata($data);
+      $this->setData($data);
     }
 
     return (empty($this->data['cache']) || is_null($this->cache_handler))

--- a/lib/Helper/Content_Render/Process.php
+++ b/lib/Helper/Content_Render/Process.php
@@ -117,7 +117,7 @@ class Process {
 
     if (!empty($k)) {
       $tpl = $this->data[$k];
-      return at_container('twig_string')->render($tpl, $this->args);
+      return trim(at_container('twig_string')->render($tpl, $this->args));
     }
   }
 }

--- a/lib/Helper/Real_Path.php
+++ b/lib/Helper/Real_Path.php
@@ -37,7 +37,7 @@ class Real_Path {
    */
   private function replaceModuleToken($path) {
     if ('@' === substr($path, 0, 1)) {
-      preg_match('/@([a-z_]+)/i', $path, $matches);
+      preg_match('/@([a-z0-9_]+)/i', $path, $matches);
       if (!empty($matches)) {
         $module = $matches[1];
         if ($module_path = drupal_get_path('module', $module)) {

--- a/lib/Helper/Real_Path.php
+++ b/lib/Helper/Real_Path.php
@@ -66,7 +66,7 @@ class Real_Path {
    */
   private function replaceLibraryToken($path, $include_drupal_root) {
     if ('%' === substr($path, 0, 1)) {
-      preg_match('/%([a-z_\.]+)/i', $path, $matches);
+      preg_match('/%([a-z0-9_\.]+)/i', $path, $matches);
       
       if (!empty($matches)) {
         $library = $matches[1];

--- a/tests/atest_base/config/blocks.yml
+++ b/tests/atest_base/config/blocks.yml
@@ -17,3 +17,10 @@ blocks:
     content:
       template_string: "Hello {{ name }}"
       variables: {name: 'Andy Truong'}
+  hi_tse:
+    info: 'Hello Template String Empty'
+    subject: 'Hello Template String Empty'
+    content:
+      template_string: >
+      {% if false %}
+      {% endif %}


### PR DESCRIPTION
If the logic in block return empty, the render still return some extra space. That make Drupal understand that block have content and still render that block.
